### PR TITLE
improvements to persisting job names in redis

### DIFF
--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -22,13 +22,18 @@ module Resque
       mattr_accessor :jobs_to_be_measured
       @@jobs_to_be_measured = []
 
-      def self.setup
-        yield self
+      #def self.setup
+        #yield self
 
-        @@jobs_to_be_measured.each do |job_name|
-          Resque.redis.sadd("stats:jobs", name)
-        end
-        Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
+        #@@jobs_to_be_measured.each do |job_name|
+          #Resque.redis.sadd("stats:jobs", name)
+        #end
+        #Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
+      #end
+
+      def self.extended(base)
+        self.jobs_to_be_measured << base
+        puts "............ jobs_to_be_measured #{self.jobs_to_be_measured}"
       end
 
       def self.add_measured_job(name)
@@ -40,7 +45,8 @@ module Resque
       end
 
       def self.measured_jobs
-        Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
+        #Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
+        self.jobs_to_be_measured
       end
     end
   end

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -17,6 +17,19 @@ module Resque
       include Resque::Plugins::JobStats::Timeseries::Enqueued
       include Resque::Plugins::JobStats::Timeseries::Performed
       include Resque::Plugins::JobStats::History
+      
+      # Define jobs_to_be_measured
+      mattr_accessor :jobs_to_be_measured
+      @@jobs_to_be_measured = []
+
+      def self.setup
+        yield self
+
+        @@jobs_to_be_measured.each do |job_name|
+          Resque.redis.sadd("stats:jobs", name)
+        end
+        Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
+      end
 
       def self.add_measured_job(name)
         Resque.redis.sadd("stats:jobs", name)

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -18,22 +18,8 @@ module Resque
       include Resque::Plugins::JobStats::Timeseries::Performed
       include Resque::Plugins::JobStats::History
       
-      # Define jobs_to_be_measured
-      mattr_accessor :jobs_to_be_measured
-      @@jobs_to_be_measured = []
-
-      #def self.setup
-        #yield self
-
-        #@@jobs_to_be_measured.each do |job_name|
-          #Resque.redis.sadd("stats:jobs", name)
-        #end
-        #Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
-      #end
-
       def self.extended(base)
-        self.jobs_to_be_measured << base
-        puts "............ jobs_to_be_measured #{self.jobs_to_be_measured}"
+        Resque.redis.sadd("stats:jobs", base.to_s)
       end
 
       def self.add_measured_job(name)
@@ -45,8 +31,7 @@ module Resque
       end
 
       def self.measured_jobs
-        #Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
-        self.jobs_to_be_measured
+        Resque.redis.smembers("stats:jobs").collect { |c| c rescue nil }.compact
       end
     end
   end

--- a/lib/resque/plugins/job_stats/duration.rb
+++ b/lib/resque/plugins/job_stats/duration.rb
@@ -24,7 +24,6 @@ module Resque
           yield
           duration = Time.now - start
 
-         #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.lpush(jobs_duration_key, duration)
           Resque.redis.ltrim(jobs_duration_key, 0, durations_recorded)
         end

--- a/lib/resque/plugins/job_stats/duration.rb
+++ b/lib/resque/plugins/job_stats/duration.rb
@@ -24,7 +24,7 @@ module Resque
           yield
           duration = Time.now - start
 
-          Resque::Plugins::JobStats.add_measured_job(self.name)
+         #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.lpush(jobs_duration_key, duration)
           Resque.redis.ltrim(jobs_duration_key, 0, durations_recorded)
         end

--- a/lib/resque/plugins/job_stats/enqueued.rb
+++ b/lib/resque/plugins/job_stats/enqueued.rb
@@ -8,7 +8,6 @@ module Resque
 
         # Sets the number of jobs queued
         def jobs_enqueued=(int)
-          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_enqueued_key,int)
         end
 
@@ -24,7 +23,6 @@ module Resque
 
         # Increments the enqueued count when job is queued
         def after_enqueue_job_stats_enqueued(*args)
-          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_enqueued_key)
         end
 

--- a/lib/resque/plugins/job_stats/enqueued.rb
+++ b/lib/resque/plugins/job_stats/enqueued.rb
@@ -8,7 +8,7 @@ module Resque
 
         # Sets the number of jobs queued
         def jobs_enqueued=(int)
-          Resque::Plugins::JobStats.add_measured_job(self.name)
+          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_enqueued_key,int)
         end
 
@@ -24,7 +24,7 @@ module Resque
 
         # Increments the enqueued count when job is queued
         def after_enqueue_job_stats_enqueued(*args)
-          Resque::Plugins::JobStats.add_measured_job(self.name)
+          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_enqueued_key)
         end
 

--- a/lib/resque/plugins/job_stats/failed.rb
+++ b/lib/resque/plugins/job_stats/failed.rb
@@ -8,7 +8,6 @@ module Resque
 
         # Sets the number of jobs failed
         def jobs_failed=(int)
-          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_failed_key,int)
         end
 
@@ -26,7 +25,6 @@ module Resque
 
         # Increments the failed count when job is complete
         def on_failure_job_stats_failed(e,*args)
-          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_failed_key)
         end
 

--- a/lib/resque/plugins/job_stats/failed.rb
+++ b/lib/resque/plugins/job_stats/failed.rb
@@ -8,7 +8,7 @@ module Resque
 
         # Sets the number of jobs failed
         def jobs_failed=(int)
-          Resque::Plugins::JobStats.add_measured_job(self.name)
+          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_failed_key,int)
         end
 
@@ -26,7 +26,7 @@ module Resque
 
         # Increments the failed count when job is complete
         def on_failure_job_stats_failed(e,*args)
-          Resque::Plugins::JobStats.add_measured_job(self.name)
+          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_failed_key)
         end
 

--- a/lib/resque/plugins/job_stats/performed.rb
+++ b/lib/resque/plugins/job_stats/performed.rb
@@ -8,7 +8,6 @@ module Resque
 
         # Sets the number of jobs performed
         def jobs_performed=(int)
-          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_performed_key,int)
         end
 
@@ -24,7 +23,6 @@ module Resque
 
         # Increments the performed count when job is complete
         def after_perform_job_stats_performed(*args)
-          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_performed_key)
         end
 

--- a/lib/resque/plugins/job_stats/performed.rb
+++ b/lib/resque/plugins/job_stats/performed.rb
@@ -8,7 +8,7 @@ module Resque
 
         # Sets the number of jobs performed
         def jobs_performed=(int)
-          Resque::Plugins::JobStats.add_measured_job(self.name)
+          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_performed_key,int)
         end
 
@@ -24,7 +24,7 @@ module Resque
 
         # Increments the performed count when job is complete
         def after_perform_job_stats_performed(*args)
-          Resque::Plugins::JobStats.add_measured_job(self.name)
+          #Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_performed_key)
         end
 

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -41,7 +41,6 @@ module Resque
           end
 
           def incr_timeseries(type) # :nodoc:
-            #Resque::Plugins::JobStats.add_measured_job(self.name)
             increx(jobs_timeseries_key(type, timestamp, :minutes), (60 * 61)) # 1h + 1m for some buffer
             increx(jobs_timeseries_key(type, timestamp, :hours), (60 * 60 * 25)) # 24h + 60m for some buffer
           end

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -41,7 +41,7 @@ module Resque
           end
 
           def incr_timeseries(type) # :nodoc:
-            Resque::Plugins::JobStats.add_measured_job(self.name)
+            #Resque::Plugins::JobStats.add_measured_job(self.name)
             increx(jobs_timeseries_key(type, timestamp, :minutes), (60 * 61)) # 1h + 1m for some buffer
             increx(jobs_timeseries_key(type, timestamp, :hours), (60 * 60 * 25)) # 24h + 60m for some buffer
           end

--- a/test/test_job_stats.rb
+++ b/test/test_job_stats.rb
@@ -35,6 +35,10 @@ class CustomHistJob < BaseJob
   @histories_recordable = 5
 end
 
+class SimpleOneTimeJob < BaseJob
+  @queue = :test
+end
+
 class TestResqueJobStats < MiniTest::Unit::TestCase
 
   def setup
@@ -143,10 +147,7 @@ class TestResqueJobStats < MiniTest::Unit::TestCase
 
   def test_measured_jobs
     assert_equal [], Resque::Plugins::JobStats.measured_jobs
-    3.times do
-      Resque.enqueue(SimpleJob,1)
-      @worker.work(0)
-    end
+    SimpleJob.extend Resque::Plugins::JobStats
     assert_equal ["SimpleJob"], Resque::Plugins::JobStats.measured_jobs
   end
 


### PR DESCRIPTION
As per this comment https://github.com/alanpeabody/resque-job-stats/pull/32#issuecomment-356472782 made changes to avoid duplicating the redis write operations.