### PR TITLE
Persisting measured jobs

### DIFF
--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -11,7 +11,7 @@ require 'resque/plugins/job_stats/history'
 module Resque
   module Plugins
     module JobStats
-      extend Resque::Plugins::JobStats::MeasuredHook
+      include Resque::Plugins::JobStats::MeasuredHook
       include Resque::Plugins::JobStats::Performed
       include Resque::Plugins::JobStats::Enqueued
       include Resque::Plugins::JobStats::Failed

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -1,4 +1,5 @@
 require 'resque'
+require 'resque/plugins/job_stats/measured_hook'
 require 'resque/plugins/job_stats/performed'
 require 'resque/plugins/job_stats/enqueued'
 require 'resque/plugins/job_stats/failed'
@@ -10,6 +11,7 @@ require 'resque/plugins/job_stats/history'
 module Resque
   module Plugins
     module JobStats
+      extend Resque::Plugins::JobStats::MeasuredHook
       include Resque::Plugins::JobStats::Performed
       include Resque::Plugins::JobStats::Enqueued
       include Resque::Plugins::JobStats::Failed
@@ -17,13 +19,17 @@ module Resque
       include Resque::Plugins::JobStats::Timeseries::Enqueued
       include Resque::Plugins::JobStats::Timeseries::Performed
       include Resque::Plugins::JobStats::History
+      
+      def self.add_measured_job(name)
+        Resque.redis.sadd("stats:jobs", name)
+      end
 
-      def self.extended(base)
-        self.measured_jobs << base
+      def self.rem_measured_job(name)
+        Resque.redis.srem("stats:jobs", name)
       end
 
       def self.measured_jobs
-        @measured_jobs ||= []
+        Resque.redis.smembers("stats:jobs").collect { |c| Object.const_get(c) rescue nil }.compact
       end
     end
   end

--- a/lib/resque/plugins/job_stats/duration.rb
+++ b/lib/resque/plugins/job_stats/duration.rb
@@ -2,7 +2,7 @@ module Resque
   module Plugins
     module JobStats
       module Duration
-        extend Resque::Plugins::JobStats::MeasuredHook
+        include Resque::Plugins::JobStats::MeasuredHook
 
         # Resets all job durations
         def reset_job_durations

--- a/lib/resque/plugins/job_stats/duration.rb
+++ b/lib/resque/plugins/job_stats/duration.rb
@@ -2,6 +2,7 @@ module Resque
   module Plugins
     module JobStats
       module Duration
+        extend Resque::Plugins::JobStats::MeasuredHook
 
         # Resets all job durations
         def reset_job_durations

--- a/lib/resque/plugins/job_stats/enqueued.rb
+++ b/lib/resque/plugins/job_stats/enqueued.rb
@@ -5,7 +5,7 @@ module Resque
       # Extend your job with this module to track how many
       # jobs are queued successfully
       module Enqueued
-        extend Resque::Plugins::JobStats::MeasuredHook
+        include Resque::Plugins::JobStats::MeasuredHook
 
         # Sets the number of jobs queued
         def jobs_enqueued=(int)

--- a/lib/resque/plugins/job_stats/enqueued.rb
+++ b/lib/resque/plugins/job_stats/enqueued.rb
@@ -5,6 +5,7 @@ module Resque
       # Extend your job with this module to track how many
       # jobs are queued successfully
       module Enqueued
+        extend Resque::Plugins::JobStats::MeasuredHook
 
         # Sets the number of jobs queued
         def jobs_enqueued=(int)

--- a/lib/resque/plugins/job_stats/failed.rb
+++ b/lib/resque/plugins/job_stats/failed.rb
@@ -5,6 +5,7 @@ module Resque
       # Extend your job with this module to track how many
       # jobs fail
       module Failed
+        extend Resque::Plugins::JobStats::MeasuredHook
 
         # Sets the number of jobs failed
         def jobs_failed=(int)

--- a/lib/resque/plugins/job_stats/failed.rb
+++ b/lib/resque/plugins/job_stats/failed.rb
@@ -5,7 +5,7 @@ module Resque
       # Extend your job with this module to track how many
       # jobs fail
       module Failed
-        extend Resque::Plugins::JobStats::MeasuredHook
+        include Resque::Plugins::JobStats::MeasuredHook
 
         # Sets the number of jobs failed
         def jobs_failed=(int)

--- a/lib/resque/plugins/job_stats/measured_hook.rb
+++ b/lib/resque/plugins/job_stats/measured_hook.rb
@@ -3,8 +3,18 @@ module Resque
     module JobStats
       module MeasuredHook
 
-        def extended(base)
-          Resque.redis.sadd("stats:jobs", base)
+        def self.included(base)
+          base.extend ClassMethods
+        end
+
+        module ClassMethods
+          def extended(base)
+            Resque::Plugins::JobStats.add_measured_job(base)
+          end
+        end
+
+        def inherited(subclass)
+          subclass.extend Resque::Plugins::JobStats
         end
 
       end

--- a/lib/resque/plugins/job_stats/measured_hook.rb
+++ b/lib/resque/plugins/job_stats/measured_hook.rb
@@ -1,0 +1,13 @@
+module Resque
+  module Plugins
+    module JobStats
+      module MeasuredHook
+
+        def extended(base)
+          Resque.redis.sadd("stats:jobs", base)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/job_stats/performed.rb
+++ b/lib/resque/plugins/job_stats/performed.rb
@@ -5,7 +5,7 @@ module Resque
       # Extend your job with this module to track how many
       # jobs are performed successfully
       module Performed
-        extend Resque::Plugins::JobStats::MeasuredHook
+        include Resque::Plugins::JobStats::MeasuredHook
 
         # Sets the number of jobs performed
         def jobs_performed=(int)

--- a/lib/resque/plugins/job_stats/performed.rb
+++ b/lib/resque/plugins/job_stats/performed.rb
@@ -5,6 +5,7 @@ module Resque
       # Extend your job with this module to track how many
       # jobs are performed successfully
       module Performed
+        extend Resque::Plugins::JobStats::MeasuredHook
 
         # Sets the number of jobs performed
         def jobs_performed=(int)

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -57,6 +57,7 @@ module Resque
 end
 
 module Resque::Plugins::JobStats::Timeseries::Enqueued
+  extend Resque::Plugins::JobStats::MeasuredHook
   include Resque::Plugins::JobStats::Timeseries::Common
 
   # Increments the enqueued count for the timestamp when job is queued
@@ -76,6 +77,7 @@ module Resque::Plugins::JobStats::Timeseries::Enqueued
 end
 
 module Resque::Plugins::JobStats::Timeseries::Performed
+  extend Resque::Plugins::JobStats::MeasuredHook
   include Resque::Plugins::JobStats::Timeseries::Common
 
   # Increments the performed count for the timestamp when job is complete

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -57,7 +57,7 @@ module Resque
 end
 
 module Resque::Plugins::JobStats::Timeseries::Enqueued
-  extend Resque::Plugins::JobStats::MeasuredHook
+  include Resque::Plugins::JobStats::MeasuredHook
   include Resque::Plugins::JobStats::Timeseries::Common
 
   # Increments the enqueued count for the timestamp when job is queued
@@ -77,7 +77,7 @@ module Resque::Plugins::JobStats::Timeseries::Enqueued
 end
 
 module Resque::Plugins::JobStats::Timeseries::Performed
-  extend Resque::Plugins::JobStats::MeasuredHook
+  include Resque::Plugins::JobStats::MeasuredHook
   include Resque::Plugins::JobStats::Timeseries::Common
 
   # Increments the performed count for the timestamp when job is complete

--- a/test/test_job_stats.rb
+++ b/test/test_job_stats.rb
@@ -35,8 +35,13 @@ class CustomHistJob < BaseJob
   @histories_recordable = 5
 end
 
-class SimpleOneTimeJob < BaseJob
+class LoadedBaseJob
+  extend Resque::Plugins::JobStats
   @queue = :test
+
+  def self.perform(sleep_time=0.01)
+    sleep sleep_time
+  end
 end
 
 class TestResqueJobStats < MiniTest::Unit::TestCase
@@ -149,8 +154,9 @@ class TestResqueJobStats < MiniTest::Unit::TestCase
     assert_equal [], Resque::Plugins::JobStats.measured_jobs
     SimpleJob.extend Resque::Plugins::JobStats
     assert_equal [SimpleJob], Resque::Plugins::JobStats.measured_jobs
-    SimpleOneTimeJob.extend Resque::Plugins::JobStats::Failed
-    assert Resque::Plugins::JobStats.measured_jobs.include? SimpleOneTimeJob
+    FailJob.extend Resque::Plugins::JobStats::Failed
+    assert Resque::Plugins::JobStats.measured_jobs.include? FailJob
+    Object.const_set "LoadedChildJob", Class.new(LoadedBaseJob)
   end
 
   def test_history


### PR DESCRIPTION
Persisting measured jobs so that stats show up in Job_Stats tab.
All job stats will be collected if just a single sub-class is inherited.
